### PR TITLE
Major refactoring before 0.2.0

### DIFF
--- a/lib/wasmtime/native.ex
+++ b/lib/wasmtime/native.ex
@@ -4,13 +4,13 @@ defmodule Wasmtime.Native do
   """
   use Rustler, otp_app: :wasmtime, crate: "wasmtime_ex"
 
-  def load_from_t(_id, _gen_pid, _from_pid, _file_name, _bin, _func_imports),
+  def load_from(_id, _gen_pid, _from_pid, _file_name, _bin, _func_ids),
     do: :erlang.nif_error(:nif_not_loaded)
 
-  def func_call(_id, _from_pid, _func_name, _params, _func_imports),
+  def func_call(_id, _gen_pid, _from_pid, _func_name, _params, _tys, _func_imports),
     do: :erlang.nif_error(:nif_not_loaded)
 
-  def call_back_reply(_id, _func_id, _results), do: :erlang.nif_error(:nif_not_loaded)
+  def exfn_reply(_id, _func_id, _results), do: :erlang.nif_error(:nif_not_loaded)
 
   def func_exports(_id, _func_imports), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/native/wasmtime_ex/src/atoms.rs
+++ b/native/wasmtime_ex/src/atoms.rs
@@ -14,7 +14,6 @@ rustler::rustler_atoms! {
     atom global_type;
     atom table_type;
     atom memory_type;
-    atom call_back;
-    atom call_back_res;
-    atom t_ctl;
+    atom call_exfn;
+    atom gen_reply;
 }

--- a/native/wasmtime_ex/src/lib.rs
+++ b/native/wasmtime_ex/src/lib.rs
@@ -1,32 +1,31 @@
-// TODO
-// use rustler::schedule::SchedulerFlags;
-
 pub mod atoms;
 pub mod session;
 
 use rustler::Error as RustlerError;
 use rustler::{Atom, Encoder, Env, OwnedEnv, Pid, Term};
+use rustler::schedule::SchedulerFlags;
 
-use crate::session::{SVal, Session, TCmd};
+use crate::session::{SVal, Session};
 use crossbeam::channel::unbounded;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::error::Error;
-use std::sync::Mutex;
+use std::sync::RwLock;
 use std::thread;
 use wasmtime::Val;
 use wasmtime::*;
 
 lazy_static! {
-    static ref SESSIONS: Mutex<HashMap<u64, Box<Session>>> = Mutex::new(HashMap::new());
+    static ref SESSIONS: RwLock<HashMap<i64, Box<Session>>> = RwLock::new(HashMap::new());
 }
 
 rustler::rustler_export_nifs! {
     "Elixir.Wasmtime.Native",
     [
-        ("load_from_t", 6, load_from_t),
-        ("func_call", 5, func_call),
-        ("call_back_reply", 3, call_back_reply),
+
+        ("load_from", 6, load_from),
+        ("func_call", 7, func_call, SchedulerFlags::DirtyCpu),
+        ("exfn_reply", 3, exfn_reply, SchedulerFlags::DirtyCpu),
         ("exports", 2, exports),
         ("func_exports", 2, func_exports),
     ],
@@ -34,9 +33,9 @@ rustler::rustler_export_nifs! {
 }
 
 fn imports_term_to_valtype(
-    func_imports: Vec<(u64, Vec<Atom>, Vec<Atom>)>,
-) -> Result<Vec<(u64, Vec<ValType>, Vec<ValType>)>, Box<dyn Error>> {
-    let mut fn_imports: Vec<(u64, Vec<ValType>, Vec<ValType>)> = Vec::new();
+    func_imports: Vec<(i64, Vec<Atom>, Vec<Atom>)>
+) -> Result<Vec<(i64, Vec<ValType>, Vec<ValType>)>, Box<dyn Error>> {
+    let mut fn_imports: Vec<(i64, Vec<ValType>, Vec<ValType>)> = Vec::new();
     for (f_id, params, results) in func_imports.iter() {
         let mut par: Vec<ValType> = Vec::new();
         let mut res: Vec<ValType> = Vec::new();
@@ -64,52 +63,56 @@ fn imports_term_to_valtype(
 }
 
 fn imports_valtype_to_extern_recv(
-    fn_imports: Vec<(u64, Vec<ValType>, Vec<ValType>)>,
+    fn_imports: Vec<(i64, Vec<ValType>, Vec<ValType>)>,
     store: &Store,
-    fchs: &mut HashMap<u64, (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>)>,
+    fchs: &HashMap<i64, (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>)>,
     gen_pid: &Pid,
 ) -> Vec<Extern> {
     let mut _func_imports: Vec<Extern> = Vec::new();
     for (func_id, func_params, func_results) in fn_imports {
-        let fch: (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>) = unbounded();
-        fchs.insert(func_id, fch.clone());
-        let pid = gen_pid.clone();
-        let fun: Extern = Func::new(
-            &store,
-            FuncType::new(
-                func_params.into_boxed_slice(),
-                func_results.into_boxed_slice(),
-            ),
-            move |_, params, _results| {
-                let mut values: Vec<SVal> = Vec::new();
-                for v in params.iter() {
-                    match v {
-                        Val::I32(k) => values.push(SVal { v: Val::I32(*k) }),
-                        Val::I64(k) => values.push(SVal { v: Val::I64(*k) }),
-                        Val::F32(k) => values.push(SVal { v: Val::F32(*k) }),
-                        Val::F64(k) => values.push(SVal { v: Val::F64(*k) }),
-                        _ => (),
-                    }
-                }
-
-                let mut msg_env = OwnedEnv::new();
-                msg_env.send_and_clear(&pid, |env| {
-                    (atoms::call_back(), func_id, sval_vec_to_term(env, values)).encode(env)
-                });
-                for (i, result) in fch.1.recv().unwrap().iter().enumerate() {
-                    _results[i] = result.v.clone();
-                }
-                Ok(())
-            },
-        )
-        .into();
-        _func_imports.push(fun);
+        match fchs.get(&func_id) {
+            Some(fch) => {
+                let pid = gen_pid.clone();
+                let recv = fch.1.clone();
+                let fun: Extern = Func::new(
+                    &store,
+                    FuncType::new(
+                        func_params.into_boxed_slice(),
+                        func_results.into_boxed_slice(),
+                    ),
+                    move |_, params, _results| {
+                        let mut values: Vec<SVal> = Vec::new();
+                        for v in params.iter() {
+                            match v {
+                                Val::I32(k) => values.push(SVal { v: Val::I32(*k) }),
+                                Val::I64(k) => values.push(SVal { v: Val::I64(*k) }),
+                                Val::F32(k) => values.push(SVal { v: Val::F32(*k) }),
+                                Val::F64(k) => values.push(SVal { v: Val::F64(*k) }),
+                                _ => (),
+                            }
+                        }
+                        let mut msg_env = OwnedEnv::new();
+                        msg_env.send_and_clear(&pid, |env| {
+                            (atoms::call_exfn(), func_id, sval_vec_to_term(env, values)).encode(env)
+                        });
+                        for (i, result) in recv.recv().unwrap().iter().enumerate() {
+                            _results[i] = result.v.clone();
+                        }
+                        Ok(())
+                    },
+                )
+                .into();
+                _func_imports.push(fun);
+                ()
+            }
+            None => (),
+        };
     }
     _func_imports
 }
 
 fn imports_valtype_to_extern(
-    fn_imports: Vec<(u64, Vec<ValType>, Vec<ValType>)>,
+    fn_imports: Vec<(i64, Vec<ValType>, Vec<ValType>)>,
     store: &Store,
 ) -> Vec<Extern> {
     let mut _func_imports: Vec<Extern> = Vec::new();
@@ -128,44 +131,20 @@ fn imports_valtype_to_extern(
     _func_imports
 }
 
-fn vec_to_terms<'a>(
-    env: Env<'a>,
-    values: Vec<Val>,
-    func_ty: &[ValType],
-) -> Result<Term<'a>, RustlerError> {
-    let mut results: Vec<Term> = Vec::new();
-    for (i, v) in func_ty.iter().enumerate() {
-        match v {
-            ValType::I32 => results.push((values.get(i).unwrap().unwrap_i32()).encode(env)),
-            ValType::I64 => results.push((values.get(i).unwrap().unwrap_i64()).encode(env)),
-            ValType::F32 => results.push((values.get(i).unwrap().unwrap_f32()).encode(env)),
-            ValType::F64 => results.push((values.get(i).unwrap().unwrap_f64()).encode(env)),
-            t => {
-                return Ok((
-                    atoms::error(),
-                    std::format!("ValType not supported yet: {:?}", t),
-                )
-                    .encode(env))
-            }
-        };
-    }
-    Ok((atoms::ok(), results).encode(env))
-}
-
-fn call_back_reply<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
-    let tid: u64 = args[0].decode()?;
-    let func_id: u64 = args[1].decode()?;
+fn exfn_reply<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
+    let tid: i64 = args[0].decode()?;
+    let func_id: i64 = args[1].decode()?;
     let results: Vec<(Term, Atom)> = args[2].decode()?;
-    let results = vec_term_to_sval(results)?;
+    let results = values_to_sval(results)?;
 
-    if let Some(session) = SESSIONS.lock().unwrap().get(&tid) {
+    if let Some(session) = SESSIONS.read().unwrap().get(&tid) {
         if let Some(fch) = session.fchs.get(&func_id) {
             match fch.0.send(results) {
                 Ok(_) => Ok((atoms::ok()).encode(env)),
-                Err(_) => Ok((atoms::error(), "call_back_reply failed to send").encode(env)),
+                Err(_) => Ok((atoms::error(), "exfn_reply failed to send").encode(env)),
             }
         } else {
-            Ok((atoms::error(), "call_back_reply failed to get func_id").encode(env))
+            Ok((atoms::error(), "exfn_reply failed to get func_id").encode(env))
         }
     } else {
         Ok((
@@ -175,30 +154,24 @@ fn call_back_reply<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Rust
             .encode(env))
     }
 }
-fn load_from_t<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
-    let tid: u64 = args[0].decode()?;
+fn load_from<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
+    let tid: i64 = args[0].decode()?;
     let gen_pid: Pid = args[1].decode()?;
     let from_encoded: String = args[2].decode()?;
     let file_name: String = args[3].decode()?;
     let bin: Vec<u8> = args[4].decode()?;
-    let func_imports: Vec<(u64, Vec<Atom>, Vec<Atom>)> = args[5].decode()?;
-
-    let fn_imports = match imports_term_to_valtype(func_imports) {
-        Ok(v) => v,
-        Err(e) => return Ok((atoms::error(), e.to_string()).encode(env)),
-    };
+    let func_ids: Vec<i64> = args[5].decode()?;
 
     thread::spawn(move || {
         fn run(
-            tid: u64,
+            tid: i64,
             gen_pid: &Pid,
             from_encoded: &String,
             array: &[u8],
             file_name: String,
-            fn_imports: Vec<(u64, Vec<ValType>, Vec<ValType>)>,
+            func_ids: &Vec<i64>,
         ) -> Result<(), Box<dyn Error>> {
             let store = Store::default();
-            let mut not_stopped = true;
             let mut msg_env = OwnedEnv::new();
 
             let module = if array.len() > 0 {
@@ -213,66 +186,32 @@ fn load_from_t<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerE
                 }
             };
 
-            let tch: (
-                crossbeam::Sender<(TCmd, String, String, Vec<SVal>)>,
-                crossbeam::Receiver<(TCmd, String, String, Vec<SVal>)>,
-            ) = unbounded();
-
             let mut fchs: HashMap<
-                u64,
+                i64,
                 (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>),
             > = HashMap::new();
-            let func_imports =
-                imports_valtype_to_extern_recv(fn_imports, &store, &mut fchs, &gen_pid.clone());
-            let instance = match Instance::new(&store, &module, &*func_imports.into_boxed_slice()) {
-                Ok(v) => v,
-                Err(e) => return Err(e.into()),
-            };
-
-            let session = Box::new(Session::new(module, tch, fchs));
-            let tch_recv = session.tch.1.clone();
-            SESSIONS.lock().unwrap().insert(tid, session);
-
-            msg_env.send_and_clear(gen_pid, |env| {
-                (atoms::t_ctl(), from_encoded, atoms::ok()).encode(env)
-            });
-
-            while not_stopped {
-                let val = tch_recv.recv();
-                msg_env.send_and_clear(gen_pid, |env| {
-                    let val = val.unwrap();
-                    match val.0 {
-                        TCmd::Call => {
-                            let mut params: Vec<Term> = Vec::new();
-                            let from_encoded = val.1;
-                            let f_name = val.2;
-                            for sval in val.3 {
-                                params.push(sval_to_term(env, &sval));
-                            }
-                            let call_res = match call(env, &instance, &f_name, params) {
-                                Ok(v) => v,
-                                Err(_) => (atoms::error(), "func_call failed to call").encode(env),
-                            };
-                            (atoms::call_back_res(), from_encoded, call_res).encode(env)
-                        }
-                        TCmd::Stop => {
-                            not_stopped = true;
-                            (atoms::t_ctl(), from_encoded, atoms::ok()).encode(env)
-                        }
-                    }
-                });
+            for func_id in func_ids {
+                let fch: (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>) =
+                    unbounded();
+                fchs.insert(*func_id, fch);
             }
 
+            let session = Box::new(Session::new(module, fchs));
+            SESSIONS.write().unwrap().insert(tid, session);
+
+            msg_env.send_and_clear(gen_pid, |env| {
+                (atoms::gen_reply(), from_encoded, atoms::ok()).encode(env)
+            });
             Ok(())
         }
 
-        match run(tid, &gen_pid, &from_encoded, &bin, file_name, fn_imports) {
+        match run(tid, &gen_pid, &from_encoded, &bin, file_name, &func_ids) {
             Ok(_) => (),
             Err(e) => {
                 let mut msg_env = OwnedEnv::new();
                 msg_env.send_and_clear(&gen_pid, |env| {
                     (
-                        atoms::t_ctl(),
+                        atoms::gen_reply(),
                         from_encoded,
                         (atoms::error(), e.to_string()),
                     )
@@ -285,56 +224,116 @@ fn load_from_t<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerE
 }
 
 fn func_call<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
-    let tid: u64 = args[0].decode()?;
-    let from_encoded: String = args[1].decode()?;
-    let func_name: &str = args[2].decode()?;
-    let params: Vec<Term> = args[3].decode()?;
-    let func_imports: Vec<(u64, Vec<Atom>, Vec<Atom>)> = args[4].decode()?;
+    let tid: i64 = args[0].decode()?;
+    let gen_pid: Pid = args[1].decode()?;
+    let from_encoded: String = args[2].decode()?;
+    let func_name: String = args[3].decode()?;
+    let params: Vec<Term> = args[4].decode()?;
+    let tys: Vec<Atom> = args[5].decode()?;
 
-    if let Some(session) = SESSIONS.lock().unwrap().get(&tid) {
-        let store = Store::new(session.module.engine());
-        let fn_imports = match imports_term_to_valtype(func_imports) {
-            Ok(v) => v,
-            Err(e) => return Ok((atoms::error(), e.to_string()).encode(env)),
-        };
-        let fn_imports = imports_valtype_to_extern(fn_imports, &store);
-        let instance = match Instance::new(&store, &session.module, &*fn_imports.into_boxed_slice())
-        {
-            Ok(v) => v,
-            Err(e) => return Ok((atoms::error(), e.to_string()).encode(env)),
-        };
+    let func_imports: Vec<(i64, Vec<Atom>, Vec<Atom>)> = args[6].decode()?;
+    let fn_imports = match imports_term_to_valtype(func_imports) {
+        Ok(v) => v,
+        Err(e) => return Ok((atoms::error(), e.to_string()).encode(env)),
+    };
 
-        if let Some(func) = instance.get_func(func_name) {
-            match session.tch.0.send((
-                TCmd::Call,
-                from_encoded.to_string(),
-                func_name.to_string(),
-                vec_term_to_sval_vec(params, func.ty().params())?,
-            )) {
-                Ok(_) => Ok((atoms::ok()).encode(env)),
-                Err(_) => Ok((atoms::error(), "call_back_reply failed to send").encode(env)),
+    let svals = params_ty_sval_vec(&params, &tys)?;
+    thread::spawn(move || {
+        fn run(
+            tid: i64,
+            gen_pid: &Pid,
+            from_encoded: &String,
+            func_name: String,
+            fn_imports: Vec<(i64, Vec<ValType>, Vec<ValType>)>,
+            svals: Vec<SVal>,
+        ) -> Result<(), Box<dyn Error>> {
+            if let Some(session) = SESSIONS.read().unwrap().get(&tid) {
+                let store = Store::new(session.module.engine());
+                let func_imports = imports_valtype_to_extern_recv(
+                    fn_imports,
+                    &store,
+                    &session.fchs,
+                    &gen_pid.clone(),
+                );
+
+                let instance =
+                    match Instance::new(&store, &session.module, &*func_imports.into_boxed_slice())
+                    {
+                        Ok(v) => v,
+                        Err(e) => return Err(e.into()),
+                    };
+
+                if let Some(func) = instance.get_func(&func_name) {
+                    OwnedEnv::new().send_and_clear(&gen_pid, |env| {
+                        let mut params: Vec<Val> = Vec::new();
+                        for val in svals {
+                            params.push(val.v);
+                        }
+
+                        let call_res = match func.call(&params) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                return (atoms::gen_reply(), from_encoded, e.to_string())
+                                    .encode(env)
+                            }
+                        };
+
+                        let mut results: Vec<Term> = Vec::new();
+                        for (i, v) in func.ty().results().iter().enumerate() {
+                            match v {
+                                ValType::I32 => results
+                                    .push((call_res.get(i).unwrap().unwrap_i32()).encode(env)),
+                                ValType::I64 => results
+                                    .push((call_res.get(i).unwrap().unwrap_i64()).encode(env)),
+                                ValType::F32 => results
+                                    .push((call_res.get(i).unwrap().unwrap_f32()).encode(env)),
+                                ValType::F64 => results
+                                    .push((call_res.get(i).unwrap().unwrap_f64()).encode(env)),
+                                _ => (),
+                            };
+                        }
+
+                        (atoms::gen_reply(), from_encoded, results).encode(env)
+                    });
+                } else {
+                    return Err(std::format!("function {:?} not found", func_name).into());
+                }
+                Ok(())
+            } else {
+                Err("Wasmtime.load(payload) hasn't been called yet".into())
             }
-        } else {
-            Ok((
-                atoms::error(),
-                std::format!("function {:?} not found", func_name),
-            )
-                .encode(env))
         }
-    } else {
-        Ok((
-            atoms::error(),
-            "Wasmtime.load(payload) hasn't been called yet",
-        )
-            .encode(env))
-    }
+
+        match run(
+            tid,
+            &gen_pid,
+            &from_encoded,
+            func_name.to_string(),
+            fn_imports,
+            svals,
+        ) {
+            Ok(_) => (),
+            Err(e) => {
+                let mut msg_env = OwnedEnv::new();
+                msg_env.send_and_clear(&gen_pid, |env| {
+                    (
+                        atoms::gen_reply(),
+                        from_encoded,
+                        (atoms::error(), e.to_string()),
+                    )
+                        .encode(env)
+                });
+            }
+        };
+    });
+    Ok((atoms::ok()).encode(env))
 }
 
 fn func_exports<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
-    let tid: u64 = args[0].decode()?;
-    let func_imports: Vec<(u64, Vec<Atom>, Vec<Atom>)> = args[1].decode()?;
+    let tid: i64 = args[0].decode()?;
+    let func_imports: Vec<(i64, Vec<Atom>, Vec<Atom>)> = args[1].decode()?;
 
-    if let Some(session) = SESSIONS.lock().unwrap().get(&tid) {
+    if let Some(session) = SESSIONS.read().unwrap().get(&tid) {
         let store = Store::new(session.module.engine());
         let fn_imports = match imports_term_to_valtype(func_imports) {
             Ok(v) => v,
@@ -395,10 +394,10 @@ fn func_exports<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Rustler
 }
 
 fn exports<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError> {
-    let tid: u64 = args[0].decode()?;
-    let func_imports: Vec<(u64, Vec<Atom>, Vec<Atom>)> = args[1].decode()?;
+    let tid: i64 = args[0].decode()?;
+    let func_imports: Vec<(i64, Vec<Atom>, Vec<Atom>)> = args[1].decode()?;
 
-    if let Some(session) = SESSIONS.lock().unwrap().get(&tid) {
+    if let Some(session) = SESSIONS.read().unwrap().get(&tid) {
         let store = Store::new(session.module.engine());
         let fn_imports = match imports_term_to_valtype(func_imports) {
             Ok(v) => v,
@@ -438,62 +437,7 @@ fn exports<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, RustlerError
     }
 }
 
-fn call<'a>(
-    env: Env<'a>,
-    instance: &Instance,
-    func_name: &str,
-    params: Vec<Term>,
-) -> Result<Term<'a>, RustlerError> {
-    let func = match instance.get_func(func_name) {
-        Some(v) => v,
-        None => {
-            return Ok((
-                atoms::error(),
-                format!("failed to find `{}` function export", func_name),
-            )
-                .encode(env))
-        }
-    };
-
-    let mut call_args: Vec<Val> = Vec::new();
-    for (i, v) in func.ty().params().iter().enumerate() {
-        match v {
-            ValType::I32 => call_args.push(Val::I32({
-                let v: i32 = params[i].decode()?;
-                v
-            })),
-            ValType::I64 => {
-                let v: i64 = params[i].decode()?;
-                call_args.push(Val::I64(v));
-            }
-            // # TODO add tests for floats
-            ValType::F32 => {
-                let v: u32 = params[i].decode()?;
-                call_args.push(Val::F32(v));
-            }
-            ValType::F64 => {
-                let v: u64 = params[i].decode()?;
-                call_args.push(Val::F64(v));
-            }
-            t => {
-                return Ok((
-                    atoms::error(),
-                    std::format!("ValType not supported yet: {:?}", t),
-                )
-                    .encode(env))
-            }
-        };
-    }
-
-    let res = match func.call(&call_args) {
-        Ok(v) => v,
-        Err(e) => return Ok((atoms::error(), e.to_string()).encode(env)),
-    };
-
-    vec_to_terms(env, res.into_vec(), func.ty().results())
-}
-
-fn vec_term_to_sval(params: Vec<(Term, Atom)>) -> Result<Vec<SVal>, RustlerError> {
+fn values_to_sval(params: Vec<(Term, Atom)>) -> Result<Vec<SVal>, RustlerError> {
     let mut values: Vec<SVal> = Vec::new();
     for (param, ty) in params.iter() {
         match ty {
@@ -515,37 +459,26 @@ fn vec_term_to_sval(params: Vec<(Term, Atom)>) -> Result<Vec<SVal>, RustlerError
     Ok(values)
 }
 
-fn vec_term_to_sval_vec(params: Vec<Term>, ty: &[ValType]) -> Result<Vec<SVal>, RustlerError> {
+fn params_ty_sval_vec(params: &Vec<Term>, tys: &Vec<Atom>) -> Result<Vec<SVal>, RustlerError> {
     let mut values: Vec<SVal> = Vec::new();
-    for (param, ty) in params.iter().zip(ty) {
+    for (param, ty) in params.iter().zip(tys) {
         match ty {
-            ValType::I32 => values.push(SVal {
+            x if *x == atoms::i32() => values.push(SVal {
                 v: Val::I32(param.decode()?),
             }),
-            ValType::I64 => values.push(SVal {
+            x if *x == atoms::i64() => values.push(SVal {
                 v: Val::I64(param.decode()?),
             }),
-            ValType::F32 => values.push(SVal {
+            x if *x == atoms::f32() => values.push(SVal {
                 v: Val::F32(param.decode()?),
             }),
-            ValType::F64 => values.push(SVal {
+            x if *x == atoms::f64() => values.push(SVal {
                 v: Val::F64(param.decode()?),
             }),
             _ => (),
-            // t => format!("Unsuported type {}", t).encode(env),
         };
     }
     Ok(values)
-}
-
-fn sval_to_term<'a>(env: Env<'a>, send_val: &SVal) -> Term<'a> {
-    match send_val.v.ty() {
-        ValType::I32 => send_val.v.unwrap_i32().encode(env),
-        ValType::I64 => send_val.v.unwrap_i64().encode(env),
-        ValType::F32 => send_val.v.unwrap_f32().encode(env),
-        ValType::F64 => send_val.v.unwrap_f64().encode(env),
-        t => format!("Unsuported type {}", t).encode(env),
-    }
 }
 
 fn sval_vec_to_term<'a>(env: Env<'a>, params: Vec<SVal>) -> Term<'a> {
@@ -556,9 +489,8 @@ fn sval_vec_to_term<'a>(env: Env<'a>, params: Vec<SVal>) -> Term<'a> {
             ValType::I64 => res.push(param.v.unwrap_i64().encode(env)),
             ValType::F32 => res.push(param.v.unwrap_f32().encode(env)),
             ValType::F64 => res.push(param.v.unwrap_f64().encode(env)),
-            t => res.push(format!("Unsuported type {}", t).encode(env)),
+            _ => (),
         };
     }
-    // TODO should be able to error out.
     res.encode(env)
 }

--- a/native/wasmtime_ex/src/session.rs
+++ b/native/wasmtime_ex/src/session.rs
@@ -1,36 +1,19 @@
 use std::collections::HashMap;
-use wasmtime::{Module, Val, ValType};
-
-#[derive(Debug)]
-pub enum TCmd {
-    Call,
-    Stop,
-}
+use wasmtime::{Module, Val};
 
 pub struct Session {
     pub module: Module,
-    pub fn_imports: Vec<(u64, Vec<ValType>, Vec<ValType>)>,
-    pub tch: (
-        crossbeam::Sender<(TCmd, String, String, Vec<SVal>)>,
-        crossbeam::Receiver<(TCmd, String, String, Vec<SVal>)>,
-    ),
-    pub fchs: HashMap<u64, (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>)>,
+    pub fchs: HashMap<i64, (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>)>
 }
 
 impl Session {
     pub fn new(
         module: Module,
-        tch: (
-            crossbeam::Sender<(TCmd, String, String, Vec<SVal>)>,
-            crossbeam::Receiver<(TCmd, String, String, Vec<SVal>)>,
-        ),
-        fchs: HashMap<u64, (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>)>,
+        fchs: HashMap<i64, (crossbeam::Sender<Vec<SVal>>, crossbeam::Receiver<Vec<SVal>>)>
     ) -> Self {
         Self {
             module,
-            tch,
             fchs,
-            fn_imports: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
- Refactored NIF threaded calls fixing a core dump
- Replaced u64 with i64 index to use System.unique_integer monotonic
- Marked func_call and exfn_reply as DirtyCpu
- Replaced Mutex with RwLock for better performance and dealing with multiple readers
- Changed some returned atoms values for clarity
- Updated Session accordingly only stores the module and fchs now
- Updated some function names for clarity (breaking change)