### PR TITLE
feature/func_call_xt

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ If you were to execute this code snippet, you'd see this message in the stdout:
 "Hello from Elixir! Got 180. Returning an i32 value"
 ```
 
+The following example loads a Wasm module from the [adder.wat file](./test/data/adder.wat) (Wasmtime supports both .wasm and .wat file types). The exported function `add` is called with `[11, 9]`:
+
+```
+{:ok, pid} = Wasmtime.load(%Wasmtime.FromFile{file_path: "test/data/adder.wat"})
+{:ok, {"add", [:i32, :i32], [:i32]}} = Wasmtime.get_func(pid, "add")
+{:ok, [20]} = Wasmtime.func_call(pid, "add", [11, 9])
+```
+
 ## Docs
 
-[https://hexdocs.pm/wasmtime](https://hexdocs.pm/wasmtime).
+- [https://hexdocs.pm/wasmtime](https://hexdocs.pm/wasmtime)
+- If you're looking for more usage snippets, check out the [tests](./test/test_helper.exs) folder
+
+## Supported Wasm entities
+
+Functions are supported with the four value types `i32`, `i64`, `f32` and `f64`. Memory will be supported soon. Globals and Tables are will be considered in the future.

--- a/lib/wasmtime.ex
+++ b/lib/wasmtime.ex
@@ -60,6 +60,11 @@ defmodule Wasmtime do
   end
 
   @impl true
+  def handle_call({:func_call_xt, fn_name, params}, _from, payload) do
+    {:reply, Native.func_call_xt(Map.get(payload, :id), fn_name, params), payload}
+  end
+
+  @impl true
   def handle_call({:load_from}, from, payload) do
     payload = Map.put(payload, from |> pidref_encode, from)
 
@@ -126,6 +131,11 @@ defmodule Wasmtime do
   def func_call(pid, fn_name, params)
       when is_pid(pid) and is_bitstring(fn_name) and is_list(params) do
     GenServer.call(pid, {:func_call, fn_name, params})
+  end
+
+  def func_call_xt(pid, fn_name, params)
+      when is_pid(pid) and is_bitstring(fn_name) and is_list(params) do
+    GenServer.call(pid, {:func_call_xt, fn_name, params})
   end
 
   def exports(pid) when is_pid(pid) do

--- a/lib/wasmtime/native.ex
+++ b/lib/wasmtime/native.ex
@@ -10,6 +10,8 @@ defmodule Wasmtime.Native do
   def func_call(_id, _gen_pid, _from_pid, _func_name, _params, _func_imports),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def func_call_xt(_id, _func_name, _params), do: :erlang.nif_error(:nif_not_loaded)
+
   def exfn_reply(_id, _func_id, _results), do: :erlang.nif_error(:nif_not_loaded)
 
   def get_func(_id, _func_name, _func_imports), do: :erlang.nif_error(:nif_not_loaded)


### PR DESCRIPTION

For specific low latency use cases, when `func_call_xt` is well suited. It can be roughly 4 to 5 times faster than `func_call`:

```
Name                 ips        average  deviation         median         99th %
adder_xt        135.24 K        7.39 μs   ±102.23%        6.98 μs       15.50 μs
plus_10_xt       86.00 K       11.63 μs    ±25.84%       11.05 μs       22.17 μs
adder            21.48 K       46.56 μs    ±39.71%       41.37 μs       90.52 μs
plus_10          18.27 K       54.73 μs    ±40.48%       48.64 μs      105.83 μs
```



